### PR TITLE
Update lester.lua for linter warning

### DIFF
--- a/lester.lua
+++ b/lester.lua
@@ -451,7 +451,7 @@ function expect.fail(func, expected)
   elseif expected ~= nil then
     local found = expected == err
     if not found and type(expected) == 'string' then
-      found = string.find(tostring(err), expected, 1, true)
+      found = string.find(tostring(err), expected, 1, true) ~= nil
     end
     if not found then
       error('expected function to fail\nexpected:\n'..tostring(expected)..'\ngot:\n'..tostring(err), 2)


### PR DESCRIPTION
This variable is defined as type `boolean`. Cannot convert its type to `integer|nil`. (by sumneko.lua 3.14.0)
- `integer` cannot match `boolean`
- Type `integer` cannot match `boolean`
- Type `number` cannot match `boolean`Lua Diagnostics.(cast-local-type)